### PR TITLE
Fix process local variables

### DIFF
--- a/src/MethodProfiler/PrfMethodIntercepter.class.st
+++ b/src/MethodProfiler/PrfMethodIntercepter.class.st
@@ -15,7 +15,6 @@ PrfMethodIntercepter class >> forMethod: aMethod withProfiler: aProfiler [
 	intercepter := PrfMethodIntercepter new.
 	intercepter method: aMethod.
 	intercepter profiler: aProfiler.
-	intercepter install.
 	^intercepter
 ]
 
@@ -29,7 +28,7 @@ PrfMethodIntercepter >> afterMethod [
 PrfMethodIntercepter >> beforeMethod [
 
 	| node precedingNode |
-	thisProcess identityHash traceCr.
+	profiler callStack ensureStackIsInitialized.
 	precedingNode := profiler callStack top.
 	node := profiler
 		        nodeForMethod: method
@@ -52,10 +51,10 @@ PrfMethodIntercepter >> enable [
 
 { #category : #installation }
 PrfMethodIntercepter >> install [
-	proxy ifNil: [ 
+
+	proxy ifNil: [
 		proxy := MpMethodProxy onMethod: method handler: self.
-		proxy install.
-		proxy disable. ]
+		proxy install ]
 ]
 
 { #category : #accessing }

--- a/src/MethodProfiler/PrfMethodIntercepter.class.st
+++ b/src/MethodProfiler/PrfMethodIntercepter.class.st
@@ -22,16 +22,15 @@ PrfMethodIntercepter class >> forMethod: aMethod withProfiler: aProfiler [
 { #category : #evaluating }
 PrfMethodIntercepter >> afterMethod [
 
-	profiler callStack isEmpty ifFalse: [ profiler callStack pop exitingNode ]
+	profiler callStack pop exitingNode
 ]
 
 { #category : #evaluating }
 PrfMethodIntercepter >> beforeMethod [
 
 	| node precedingNode |
-	precedingNode := profiler callStack isEmpty
-		                 ifFalse: [ profiler callStack top ]
-		                 ifTrue: [ profiler unknownNode ].
+	thisProcess identityHash traceCr.
+	precedingNode := profiler callStack top.
 	node := profiler
 		        nodeForMethod: method
 		        withPrecedingNode: precedingNode.

--- a/src/MethodProfiler/PrfMethodNode.class.st
+++ b/src/MethodProfiler/PrfMethodNode.class.st
@@ -69,6 +69,9 @@ PrfMethodNode >> enteringNode [
 
 { #category : #'as yet unclassified' }
 PrfMethodNode >> exitingNode [
+	"Manage the case of the root unknown node"
+	lastTimeEntered ifNil: [ ^ self ].
+
 	totalTime := totalTime + (DateAndTime now - lastTimeEntered).
 	lastTimeEntered := nil 
 ]

--- a/src/MethodProfiler/PrfMethodProfiler.class.st
+++ b/src/MethodProfiler/PrfMethodProfiler.class.st
@@ -207,7 +207,7 @@ PrfMethodProfiler >> flameGraph [
 
 { #category : #initialization }
 PrfMethodProfiler >> initialize [
-	callStack := PrfProcessCallStack new.
+	callStack := PrfProcessCallStack new profiler: self.
 	intercepters := Dictionary new.
 	nodes := Dictionary new.
 	unknownNode := PrfMethodNode forMethod: nil withProfiler: self withHash: (((SHA1 new hashMessage: '') copyFrom: 1 to: 4) hex ).

--- a/src/MethodProfiler/PrfMethodProfiler.class.st
+++ b/src/MethodProfiler/PrfMethodProfiler.class.st
@@ -129,7 +129,6 @@ PrfMethodProfiler >> callStack [
 
 { #category : #initialization }
 PrfMethodProfiler >> destroy [
-	intercepters do: [ :intercepter | intercepter uninstall ].
 	intercepters removeAll.
 	nodes removeAll.
 	unknownNode := nil.
@@ -329,13 +328,13 @@ PrfMethodProfiler >> shouldWrap: aMethod [
 
 { #category : #lifecycle }
 PrfMethodProfiler >> start [
-	intercepters do: [ :intercepter | intercepter enable ].
+	intercepters do: [ :intercepter | intercepter install ].
 	profilingNow := true
 ]
 
 { #category : #lifecycle }
 PrfMethodProfiler >> stop [
-	intercepters do: [ :intercepter | intercepter disable ].
+	intercepters do: [ :intercepter | intercepter uninstall ].
 	profilingNow := false
 ]
 

--- a/src/MethodProfiler/PrfProcessCallStack.class.st
+++ b/src/MethodProfiler/PrfProcessCallStack.class.st
@@ -31,16 +31,10 @@ PrfProcessCallStack >> initialize [
 	stacks := IdentitySet new
 ]
 
-{ #category : #testing }
-PrfProcessCallStack >> isEmpty [ 
-	self ensureStackIsInitialized.
-	^self value isEmpty 
-]
-
 { #category : #removing }
 PrfProcessCallStack >> pop [
-	self ensureStackIsInitialized.
-	^self value pop
+	"Precondition, the process variable is already initialized"
+	^ self value pop
 ]
 
 { #category : #accessing }
@@ -64,12 +58,10 @@ PrfProcessCallStack >> push: anElement [
 { #category : #accessing }
 PrfProcessCallStack >> size [
 
-	self value ifNil: [ ^ 0 ].
 	^ self value size
 ]
 
 { #category : #accessing }
 PrfProcessCallStack >> top [ 
-	self ensureStackIsInitialized.
 	^self value top
 ]

--- a/src/MethodProfiler/PrfProcessCallStack.class.st
+++ b/src/MethodProfiler/PrfProcessCallStack.class.st
@@ -1,12 +1,34 @@
 Class {
 	#name : #PrfProcessCallStack,
 	#superclass : #ProcessLocalVariable,
+	#instVars : [
+		'profiler',
+		'stacks'
+	],
 	#category : #MethodProfiler
 }
 
 { #category : #initialization }
 PrfProcessCallStack >> ensureStackIsInitialized [
-	self value ifNil: [ self value: Stack new ].
+	
+	"A new thread requires a stack.
+	Initialize it and store it.
+	Otherwise, the process specific variable is stored in a weak array"
+	| theStack |
+	self value ifNotNil: [ ^ self ].
+	
+	theStack := Stack new.
+	theStack push: profiler unknownNode.
+	stacks add: theStack.
+	
+	self value: theStack.
+]
+
+{ #category : #initialization }
+PrfProcessCallStack >> initialize [
+
+	super initialize.
+	stacks := IdentitySet new
 ]
 
 { #category : #testing }
@@ -19,6 +41,18 @@ PrfProcessCallStack >> isEmpty [
 PrfProcessCallStack >> pop [
 	self ensureStackIsInitialized.
 	^self value pop
+]
+
+{ #category : #accessing }
+PrfProcessCallStack >> profiler [
+
+	^ profiler
+]
+
+{ #category : #accessing }
+PrfProcessCallStack >> profiler: anObject [
+
+	profiler := anObject
 ]
 
 { #category : #adding }


### PR DESCRIPTION
Fixes https://github.com/BastouP411/MethodProfiler/issues/3 and others probably too.

Process local state is stored as a weak array. And the call stack of the profiler is stored only in the process local variable. This means that when a GC runs (and that's why this happens with longish executions), the stack is lost.

Moreover, the stack is now lazily initialized (i.e., if the value is nil), and since the GC puts nil, the stack is re-initialized, masking the error and pushing it for later.

This PR introduces a couple of improvements. First, stacks should be kept strongly by the profiler.
Second, proxies are installed/uninstalled in a safer way.